### PR TITLE
Premature return causes the plugin to incorrectly identify fixtures as unused

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -11,6 +11,8 @@ Contributors
 ------------
 
 * Jair Henrique - `@jairhenrique`_
+* Tawonga - `@tawonga`_
 
 .. _`@jllorencetti`: https://github.com/jllorencetti
 .. _`@jairhenrique`: https://github.com/jairhenrique
+.. _`@tawonga`: https://github.com/tawonga

--- a/pytest_deadfixtures.py
+++ b/pytest_deadfixtures.py
@@ -99,7 +99,7 @@ def get_used_fixturesdefs(session):
             return fixturesdefs
         if not info.name2fixturedefs:
             # this test item does not use any fixtures
-            return fixturesdefs
+            continue
 
         for _, fixturedefs in sorted(info.name2fixturedefs.items()):
             if fixturedefs is None:

--- a/tests/test_deadfixtures.py
+++ b/tests/test_deadfixtures.py
@@ -247,7 +247,7 @@ def test_do_not_list_fixture_used_after_test_which_does_not_use_fixtures(testdir
         @pytest.fixture()
         def same_file_fixture():
             return 1
-      
+
         def test_no_fixture_used():
             assert True
 

--- a/tests/test_deadfixtures.py
+++ b/tests/test_deadfixtures.py
@@ -239,7 +239,7 @@ def test_should_not_list_fixtures_from_site_packages_directory(
     assert message not in result.stdout.str()
 
 
-def test_do_not_list_fixture_used_after_test_which_does_not_use_fixtures(testdir, message_template):
+def test_dont_list_fixture_used_after_test_which_does_not_use_fixtures(testdir, message_template):
     testdir.makepyfile("""
         import pytest
 

--- a/tests/test_deadfixtures.py
+++ b/tests/test_deadfixtures.py
@@ -237,3 +237,29 @@ def test_should_not_list_fixtures_from_site_packages_directory(
 
     assert result.ret == 0
     assert message not in result.stdout.str()
+
+
+def test_do_not_list_fixture_used_after_test_which_does_not_use_fixtures(testdir, message_template):
+    testdir.makepyfile("""
+        import pytest
+
+
+        @pytest.fixture()
+        def same_file_fixture():
+            return 1
+      
+        def test_no_fixture_used():
+            assert True
+
+        def test_simple(same_file_fixture):
+            assert 1 == same_file_fixture
+    """)
+
+    result = testdir.runpytest('--dead-fixtures')
+    message = message_template.format(
+        'same_file_fixture',
+        'test_dont_list_fixture_used_after_test_which_does_not_use_fixtures'
+    )
+
+    assert result.ret == 0
+    assert message not in result.stdout.str()


### PR DESCRIPTION
Fixes #11