### PR TITLE
Group fixtures

### DIFF
--- a/pytest_deadfixtures.py
+++ b/pytest_deadfixtures.py
@@ -207,6 +207,7 @@ def show_dead_fixtures(config, session):
     unused_fixtures = [fixture for fixture in available_fixtures
                        if fixture.fixturedef not in used_fixtures]
 
+    tw.line()
     if unused_fixtures:
         tw.line(UNUSED_FIXTURES_FOUND_HEADLINE, red=True)
         write_fixtures(tw, unused_fixtures, verbose)

--- a/pytest_deadfixtures.py
+++ b/pytest_deadfixtures.py
@@ -93,7 +93,7 @@ def get_fixtures(session):
                     fixturedef
                 ))
 
-    available.sort()
+    available.sort(key=lambda a: a.relpath)
     return available
 
 
@@ -207,7 +207,6 @@ def show_dead_fixtures(config, session):
     unused_fixtures = [fixture for fixture in available_fixtures
                        if fixture.fixturedef not in used_fixtures]
 
-    tw.line()
     if unused_fixtures:
         tw.line(UNUSED_FIXTURES_FOUND_HEADLINE, red=True)
         write_fixtures(tw, unused_fixtures, verbose)


### PR DESCRIPTION
![gnome-shell-screenshot-jarzqz](https://user-images.githubusercontent.com/247603/47051240-cfa8e300-d179-11e8-9ac7-dbb91f91e18b.png)

I think grouping fixtures by their location makes more sense (since, probably, we are going to remove it sequentially)