### PR TITLE
Support for dinamically generated fixtures

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -16,3 +16,4 @@ Contributors
 .. _`@jllorencetti`: https://github.com/jllorencetti
 .. _`@jairhenrique`: https://github.com/jairhenrique
 .. _`@tawonga`: https://github.com/tawonga
+.. _`@MatheusBrochi`: https://github.com/MatheusBrochi

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changelog
 ---------
 
+2.2.1
+~~~~~
+
+* Support for dinamically generated fixtures
+
 2.2.0
 ~~~~~
 

--- a/pytest_deadfixtures.py
+++ b/pytest_deadfixtures.py
@@ -86,6 +86,7 @@ def get_fixtures(session):
                 and not module.startswith("pytest_")
                 and not ("site-packages" in loc)
                 and not ("dist-packages" in loc)
+                and not ("<string>" in loc)
             ):
                 available.append(
                     AvailableFixture(

--- a/tests/test_deadfixtures.py
+++ b/tests/test_deadfixtures.py
@@ -347,7 +347,7 @@ def test_repeated_fixtures_found(testdir):
     assert "someclass_samefixture" in result.stdout.str()
 
 
-@pytest.mark.parametrize("directory", ("site-packages", "dist-packages"))
+@pytest.mark.parametrize("directory", ("site-packages", "dist-packages", "<string>"))
 def test_should_not_list_fixtures_from_unrelated_directories(
     testdir, message_template, directory
 ):


### PR DESCRIPTION
The proposal of this PR is to ignore dinamically generated fixtures (like those from pytest-factoryboy).
The location of these fixtures is `<string>:line`, so, ignoring `loc`s with `<string>` seems to fix this problem.

This PR closes https://github.com/jllorencetti/pytest-deadfixtures/issues/22
