### PR TITLE
Adds more test cases

### DIFF
--- a/tests/test_deadfixtures.py
+++ b/tests/test_deadfixtures.py
@@ -438,3 +438,145 @@ def test_doctest_should_not_result_in_false_positive(testdir, message_template):
     )
 
     assert message not in result.stdout.str()
+
+
+def test_dont_list_fixture_used_by_another_fixture(testdir, message_template):
+    testdir.makepyfile(
+        """
+        import pytest
+
+
+        @pytest.fixture()
+        def some_fixture():
+            return 1
+
+        @pytest.fixture()
+        def a_derived_fixture(some_fixture):
+            return some_fixture + 1
+
+        def test_something(a_derived_fixture):
+            assert a_derived_fixture == 2
+    """
+    )
+
+    result = testdir.runpytest("--dead-fixtures")
+
+    for fixture_name in ["some_fixture", "a_derived_fixture"]:
+        message = message_template.format(
+            fixture_name, "test_dont_list_fixture_used_by_another_fixture",
+        )
+        assert message not in result.stdout.str()
+
+
+def test_list_derived_fixtures_if_not_used_by_tests(testdir, message_template):
+    testdir.makepyfile(
+        """
+        import pytest
+
+
+        @pytest.fixture()
+        def some_fixture():
+            return 1
+
+        @pytest.fixture()
+        def a_derived_fixture(some_fixture):
+            return some_fixture + 1
+
+        def test_something():
+            assert True
+    """
+    )
+
+    result = testdir.runpytest("--dead-fixtures")
+
+    # although some_fixture is used by a_derived_fixture, since neither are used by a test case,
+    # they should be reported.
+    for fixture_name in ["some_fixture", "a_derived_fixture"]:
+        message = message_template.format(
+            fixture_name, "test_list_derived_fixtures_if_not_used_by_tests",
+        )
+        assert message in result.stdout.str()
+
+
+def test_imported_fixtures(testdir):
+
+    testdir.makepyfile(
+        conftest="""
+        import pytest
+
+        pytest_plugins = [
+            'more_fixtures',
+        ]
+
+        @pytest.fixture
+        def some_common_fixture():
+            return 'ok'
+    """
+    )
+    testdir.makepyfile(
+        more_fixtures="""
+        import pytest
+
+        @pytest.fixture
+        def some_fixture():
+            return 1
+
+        @pytest.fixture
+        def a_derived_fixture(some_fixture):
+            return some_fixture + 1
+
+        @pytest.fixture
+        def some_unused_fixture():
+            return 'nope'
+    """
+    )
+    testdir.makepyfile(
+        """
+        import pytest
+
+        def test_some_common_thing(some_common_fixture):
+            assert True
+
+        def test_some_derived_thing(a_derived_fixture):
+            assert True
+    """
+    )
+
+    result = testdir.runpytest("--dead-fixtures")
+
+    for fixture_name in ["some_fixture", "a_derived_fixture", "some_common_fixture"]:
+        assert fixture_name not in result.stdout.str()
+
+    assert "some_unused_fixture" in result.stdout.str()
+
+
+def test_parameterized_fixture(testdir):
+    testdir.makepyfile(
+        conftest="""
+        import pytest
+
+        @pytest.fixture
+        def some_common_fixture():
+            return 1
+    """
+    )
+    testdir.makepyfile(
+        """
+        import pytest
+
+        @pytest.fixture(params=['some_common_fixture'])
+        def another_fixture(request)
+            fixture_value = request.getfixturevalue(request.param)
+            return fixture_value + 1
+
+        def test_a_thing(another_fixture):
+            assert another_fixture == 2
+    """
+    )
+
+    result = testdir.runpytest("--dead-fixtures")
+
+    # TODO https://github.com/jllorencetti/pytest-deadfixtures/issues/28
+    # Currently these cases ARE recognized as a false positive, whereas they shouldn't be.
+    # Due to the dynamic lookup of the fixture, this is going to be hard to recognize.
+    assert "some_common_fixture" in result.stdout.str()

--- a/tests/test_deadfixtures.py
+++ b/tests/test_deadfixtures.py
@@ -550,6 +550,7 @@ def test_imported_fixtures(testdir):
     assert "some_unused_fixture" in result.stdout.str()
 
 
+@pytest.mark.xfail(reason="https://github.com/jllorencetti/pytest-deadfixtures/issues/28")
 def test_parameterized_fixture(testdir):
     testdir.makepyfile(
         conftest="""
@@ -576,7 +577,6 @@ def test_parameterized_fixture(testdir):
 
     result = testdir.runpytest("--dead-fixtures")
 
-    # TODO https://github.com/jllorencetti/pytest-deadfixtures/issues/28
-    # Currently these cases ARE recognized as a false positive, whereas they shouldn't be.
+    # Currently these cases are recognized as a false positive, whereas they shouldn't be.
     # Due to the dynamic lookup of the fixture, this is going to be hard to recognize.
-    assert "some_common_fixture" in result.stdout.str()
+    assert "some_common_fixture" not in result.stdout.str()


### PR DESCRIPTION
## RATIONALE
While using the tool, I noticed there was a long list of false positives and was curious why.  I added some simple test cases for situations that weren't covered yet with the goal of better understanding what this plugin does and does not support.

## TESTING
Tested with:
```
tox -e py38
```
with result:
```
============================================================================================================================= test session starts ==============================================================================================================================
platform darwin -- Python 3.8.5, pytest-6.1.0, py-1.9.0, pluggy-0.13.1
cachedir: .tox/py38/.pytest_cache
rootdir: /Users/dustin/Developer/open_source/pytest-deadfixtures
plugins: deadfixtures-2.2.1
collected 22 items

tests/test_deadfixtures.py .....................x                                                                                                                                                                                                                        [100%]

======================================================================================================================== 21 passed, 1 xfailed in 1.34s =========================================================================================================================```