### PR TITLE
Issue 47

### DIFF
--- a/pytest_deadfixtures.py
+++ b/pytest_deadfixtures.py
@@ -180,7 +180,7 @@ def same_fixture(one, two):
     def same_result(a, b):
         if not a.result or not b.result:
             return False
-        if hasattr(a.result, "__dict__") or hasattr(b.result, "__dict__"):
+        if getattr(a.result, "__dict__", None) and getattr(b.result, "__dict__", None):  
             return a.result.__dict__ == b.result.__dict__
         return a.result == b.result
 


### PR DESCRIPTION
To solve the problem of duplicate fixture detection for Callable return types, we need to modify the `same_result` function within the `same_fixture` function. Specifically, we should use `getattr` for accessing the `__dict__` attribute to ensure the comparison works correctly.