### PR TITLE
Fix cached_fixtures always keeps a reference to all fixtures

### DIFF
--- a/pytest_deadfixtures.py
+++ b/pytest_deadfixtures.py
@@ -182,7 +182,9 @@ def write_fixtures(tw, fixtures, write_docs):
 cached_fixtures = []
 
 
-def pytest_fixture_post_finalizer(fixturedef):
+def pytest_fixture_post_finalizer(fixturedef, request):
+    if not request.config.getvalue("showrepeated"):
+        return
     if getattr(fixturedef, "cached_result", None):
         curdir = py.path.local()
         loc = getlocation(fixturedef.func, curdir)

--- a/tests/test_deadfixtures.py
+++ b/tests/test_deadfixtures.py
@@ -383,6 +383,43 @@ def test_repeated_fixtures_found(pytester):
     assert "someclass_samefixture" in result.stdout.str()
 
 
+def test_fixture_values_not_kept_alive_without_dup_fixtures(pytester):
+    pytester.makepyfile(
+        """
+        import gc
+        import weakref
+
+        import pytest
+
+
+        class Payload:
+            pass
+
+
+        refs = []
+
+
+        @pytest.fixture()
+        def payload():
+            obj = Payload()
+            refs.append(weakref.ref(obj))
+            return obj
+
+
+        def test_first(payload):
+            assert payload is not None
+
+        def test_second(payload):
+            gc.collect()
+            assert refs[0]() is None, "previous fixture value is still alive"
+    """
+    )
+
+    result = pytester.runpytest()
+
+    result.assert_outcomes(passed=2)
+
+
 @pytest.mark.parametrize("directory", ("site-packages", "dist-packages", "<string>"))
 def test_should_not_list_fixtures_from_unrelated_directories(
     pytester, message_template, directory


### PR DESCRIPTION
This fixes a memory leak in the plugin. The details can be found in [issue 55](https://github.com/jllorencetti/pytest-deadfixtures/issues/55#issuecomment-5250370850). 

Fixes #55 #46 