### PR TITLE
add pytest_version matrix and fix --doctest-modules

### DIFF
--- a/pytest_deadfixtures.py
+++ b/pytest_deadfixtures.py
@@ -242,6 +242,14 @@ def show_dead_fixtures(config, session):
     available_fixtures = get_fixtures(session)
     param_fixtures = get_parametrized_fixtures(session, available_fixtures)
 
+    curdir = py.path.local()
+
+    def _fixture_key(fixturedef):
+        return fixturedef.argname, getlocation(fixturedef.func, curdir)
+
+    used_keys = {_fixture_key(fixturedef) for fixturedef in used_fixtures}
+    param_keys = {_fixture_key(fixturedef) for fixturedef in param_fixtures}
+
     # Separate ignored and unused fixtures
     ignored_fixtures = [
         fixture
@@ -252,8 +260,8 @@ def show_dead_fixtures(config, session):
     unused_fixtures = [
         fixture
         for fixture in available_fixtures
-        if fixture.fixturedef not in used_fixtures
-        and fixture.fixturedef not in param_fixtures
+        if _fixture_key(fixture.fixturedef) not in used_keys
+        and _fixture_key(fixture.fixturedef) not in param_keys
         and not is_ignored_fixture(fixture.fixturedef)
     ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pre-commit
-pytest
+pytest>=8.1.2
 pytest-cov
 tox
 tox-gh-actions

--- a/tox.ini
+++ b/tox.ini
@@ -1,3 +1,4 @@
+# For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
 envlist = py{310,311,312,313,314}-pytest{8,9}, py, pypy3, lint
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,20 +1,22 @@
-# For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-envlist = py310,py311,py312,py313,py314,py,pypy3,lint
+envlist = py{310,311,312,313,314}-pytest{8,9}, py, pypy3, lint
 
 [gh-actions]
 python =
-    3.10: py310
-    3.11: py311
-    3.12: py312
-    3.13: py313, lint
-    3.14: py314
+    3.10: py310-pytest{8,9}
+    3.11: py311-pytest{8,9}
+    3.12: py312-pytest{8,9}
+    3.13: py313-pytest{8,9}, lint
+    3.14: py314-pytest{8,9}
     pypy-3.8: pypy3
     pypy-3.9: pypy3
 
 [testenv]
-deps = -rrequirements.txt
-commands = pytest --cov pytest_deadfixtures --cov-report term-missing --cov-report xml
+deps =
+    -rrequirements.txt
+    pytest8: pytest>=8.0,<9.0
+    pytest9: pytest>=9.0,<10.0
+commands = pytest --cov pytest_deadfixtures -v --cov-report term-missing --cov-report xml
 
 [testenv:lint]
 skip_install = true


### PR DESCRIPTION
Hello

In PR:
1) add pytestVersion matrix (like https://github.com/pytest-dev/pytest-repeat/blob/main/tox.ini#L6)
2) fix --doctest-modules (in pytest 9.1.xx change https://github.com/pytest-dev/pytest/issues/14533)
3) pinned pytest>=8.1.2
4) add pytest verbose flag https://docs.pytest.org/en/stable/how-to/output.html#verbosity in tox run tests